### PR TITLE
Add Unity WebGL placeholder build and embed

### DIFF
--- a/games.html
+++ b/games.html
@@ -25,10 +25,12 @@
         <section class="section">
             <div class="container">
                 <h2>Games</h2>
-                <p>Welcome to the games page! Here you’ll find playable demos of my Unity projects. Two game demos are on their way — check back soon for the latest versions and experience what I’ve been working on.</p>
-                <div class="games-placeholder">
-                    <!-- Placeholder area for future embedded games -->
-                    <p>Game embeds will appear here when they’re ready.</p>
+                <p>Welcome to the games page! Here you’ll find playable demos of my Unity projects. Dive into the first WebGL experience below and stay tuned for additional experiments.</p>
+                <div class="game-embed">
+                    <iframe src="webgl/MyGame/index.html"
+                            title="MyGame Unity WebGL build"
+                            width="960" height="600" frameborder="0"
+                            allowfullscreen loading="lazy"></iframe>
                 </div>
             </div>
         </section>

--- a/style.css
+++ b/style.css
@@ -137,13 +137,19 @@ body {
     flex: 1;
 }
 
-/* Placeholder styling for games page */
-.games-placeholder {
+/* Embedded game wrapper on the games page */
+.game-embed {
     margin-top: 40px;
-    padding: 40px;
-    border: 2px dashed #d1d5db;
-    text-align: center;
-    color: #6b7280;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.game-embed iframe {
+    max-width: 100%;
+    border-radius: 12px;
+    border: 0;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.25);
 }
 
 /* Section styles */

--- a/webgl/MyGame/Build/MyGame.data
+++ b/webgl/MyGame/Build/MyGame.data
@@ -1,0 +1,1 @@
+Placeholder binary data file for Unity WebGL build.

--- a/webgl/MyGame/Build/MyGame.framework.js
+++ b/webgl/MyGame/Build/MyGame.framework.js
@@ -1,0 +1,1 @@
+// Placeholder framework script for Unity WebGL build.

--- a/webgl/MyGame/Build/MyGame.loader.js
+++ b/webgl/MyGame/Build/MyGame.loader.js
@@ -1,0 +1,38 @@
+(function () {
+  function drawPlaceholder() {
+    var canvas = document.getElementById('unity-canvas');
+    if (!canvas) {
+      return;
+    }
+
+    var context = canvas.getContext('2d');
+    if (!context) {
+      return;
+    }
+
+    var width = canvas.width;
+    var height = canvas.height;
+
+    context.clearRect(0, 0, width, height);
+
+    var gradient = context.createLinearGradient(0, 0, width, height);
+    gradient.addColorStop(0, '#1e3a8a');
+    gradient.addColorStop(1, '#0f172a');
+    context.fillStyle = gradient;
+    context.fillRect(0, 0, width, height);
+
+    context.fillStyle = '#f8fafc';
+    context.font = '48px Inter, Arial, sans-serif';
+    context.textAlign = 'center';
+    context.fillText('Unity WebGL Build Placeholder', width / 2, height / 2 - 20);
+
+    context.font = '24px Inter, Arial, sans-serif';
+    context.fillText('Replace with the exported build files from Unity.', width / 2, height / 2 + 30);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', drawPlaceholder);
+  } else {
+    drawPlaceholder();
+  }
+})();

--- a/webgl/MyGame/Build/MyGame.wasm
+++ b/webgl/MyGame/Build/MyGame.wasm
@@ -1,0 +1,1 @@
+// Placeholder WASM binary for Unity WebGL build.

--- a/webgl/MyGame/TemplateData/style.css
+++ b/webgl/MyGame/TemplateData/style.css
@@ -1,0 +1,33 @@
+body {
+    margin: 0;
+    font-family: Arial, Helvetica, sans-serif;
+    background: #101320;
+    color: #f3f4f6;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.unity-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px;
+}
+
+#unity-canvas {
+    width: 100%;
+    max-width: 960px;
+    border: 4px solid #2563eb;
+    border-radius: 12px;
+    background: radial-gradient(circle at top, #1f2937, #0f172a);
+}
+
+noscript {
+    max-width: 960px;
+    margin-top: 20px;
+    padding: 20px;
+    background: rgba(15, 23, 42, 0.8);
+    border-radius: 8px;
+}

--- a/webgl/MyGame/index.html
+++ b/webgl/MyGame/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>MyGame – WebGL Build</title>
+    <link rel="stylesheet" href="TemplateData/style.css">
+</head>
+<body>
+    <div class="unity-container">
+        <canvas id="unity-canvas" width="960" height="600" role="img" aria-label="Unity WebGL placeholder canvas"></canvas>
+        <noscript>
+            <p>This WebGL content requires JavaScript. Please enable JavaScript in your browser to view the Unity build.</p>
+        </noscript>
+    </div>
+    <script src="Build/MyGame.loader.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a WebGL build directory with placeholder Unity export assets for MyGame
- embed the new build on games.html and refresh the introductory copy
- style the games page embed area to center the iframe and add subtle framing

## Testing
- curl -I http://localhost:8000/games.html

------
https://chatgpt.com/codex/tasks/task_e_68c96fa76598832aa4fefb0ac818646a