### PR TITLE
Add click-to-play wrapper around WebGL game

### DIFF
--- a/games.html
+++ b/games.html
@@ -27,10 +27,21 @@
                 <h2>Games</h2>
                 <p>Welcome to the games page! Here you’ll find playable demos of my Unity projects. Dive into the latest WebGL build below and stay tuned for additional experiments.</p>
                 <div class="game-embed">
-                    <iframe src="webgl/w0.3/index.html"
-                            title="Unity WebGL build: w0.3"
-                            width="960" height="600" frameborder="0"
-                            allowfullscreen loading="lazy"></iframe>
+                    <div class="game-launcher"
+                         data-game-src="webgl/w0.3/index.html"
+                         data-game-title="Unity WebGL build: w0.3"
+                         data-game-width="960"
+                         data-game-height="600">
+                        <p class="game-launcher-text">The Unity WebGL build is a hefty download, so it won’t start automatically. Click the button below when you’re ready to load the demo.</p>
+                        <button type="button" class="game-play-button">
+                            <span class="game-play-icon" aria-hidden="true">&#9658;</span>
+                            Play the demo
+                        </button>
+                        <p class="game-launcher-hint"><a href="webgl/w0.3/index.html" target="_blank" rel="noopener">Open the build in a new tab instead</a></p>
+                    </div>
+                    <noscript>
+                        <p class="game-noscript">JavaScript is required to load the WebGL build on this page. <a href="webgl/w0.3/index.html" target="_blank" rel="noopener">Open the demo in a new tab.</a></p>
+                    </noscript>
                 </div>
             </div>
         </section>
@@ -43,7 +54,31 @@
     </footer>
 
     <script>
-    document.getElementById('games-year').textContent = new Date().getFullYear();
+    const gamesYear = document.getElementById('games-year');
+    if (gamesYear) {
+        gamesYear.textContent = new Date().getFullYear();
+    }
+
+    const gameLauncher = document.querySelector('.game-launcher');
+    if (gameLauncher) {
+        const playButton = gameLauncher.querySelector('.game-play-button');
+        const gameSrc = gameLauncher.dataset.gameSrc;
+
+        if (playButton && gameSrc) {
+            playButton.addEventListener('click', () => {
+                const iframe = document.createElement('iframe');
+                iframe.src = gameSrc;
+                iframe.title = gameLauncher.dataset.gameTitle || 'Unity WebGL build';
+                iframe.width = gameLauncher.dataset.gameWidth || '960';
+                iframe.height = gameLauncher.dataset.gameHeight || '600';
+                iframe.loading = 'lazy';
+                iframe.setAttribute('frameborder', '0');
+                iframe.setAttribute('allowfullscreen', '');
+
+                gameLauncher.replaceWith(iframe);
+            }, { once: true });
+        }
+    }
     </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -152,6 +152,98 @@ body {
     box-shadow: 0 10px 30px rgba(15, 23, 42, 0.25);
 }
 
+.game-launcher {
+    width: 100%;
+    max-width: 960px;
+    border-radius: 12px;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.25);
+    background: linear-gradient(135deg, #1a73e8 0%, #0f172a 100%);
+    padding: 60px 24px;
+    text-align: center;
+    color: #f8fafc;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+}
+
+.game-launcher-text {
+    margin: 0;
+    max-width: 520px;
+    font-size: 1.1rem;
+}
+
+.game-play-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    background-color: #ffffff;
+    color: #1a73e8;
+    border: none;
+    border-radius: 999px;
+    font-size: 1.1rem;
+    font-weight: 600;
+    padding: 14px 32px;
+    cursor: pointer;
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.18);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.game-play-button:hover {
+    background-color: #f4f8ff;
+    transform: translateY(-2px);
+    box-shadow: 0 16px 36px rgba(15, 23, 42, 0.2);
+}
+
+.game-play-button:focus-visible {
+    outline: 3px solid #dbeafe;
+    outline-offset: 4px;
+}
+
+.game-play-icon {
+    font-size: 1.2rem;
+}
+
+.game-launcher-hint {
+    margin: 0;
+    font-size: 0.95rem;
+    color: rgba(248, 250, 252, 0.9);
+}
+
+.game-launcher-hint a {
+    color: #ffffff;
+    text-decoration: underline;
+}
+
+.game-launcher-hint a:hover {
+    color: #dbeafe;
+}
+
+.game-noscript {
+    margin-top: 20px;
+    text-align: center;
+}
+
+.game-noscript a {
+    color: #1a73e8;
+}
+
+@media (max-width: 600px) {
+    .game-launcher {
+        padding: 40px 20px;
+        gap: 20px;
+    }
+
+    .game-launcher-text {
+        font-size: 1rem;
+    }
+
+    .game-play-button {
+        width: 100%;
+        justify-content: center;
+    }
+}
+
 /* Section styles */
 .section {
     padding: 60px 0;


### PR DESCRIPTION
## Summary
- replace the autoplaying WebGL iframe with a click-to-play launcher
- add styling for the launcher and fallback copy plus noscript link
- load the iframe via JavaScript only after the play button is pressed

## Testing
- no tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c97b1c143c832a9f042899045cb49a