### PR TITLE
Add placeholder sections to games page

### DIFF
--- a/games.html
+++ b/games.html
@@ -26,22 +26,47 @@
             <div class="container">
                 <h2>Games</h2>
                 <p>Try a demo of a bad game that will never be finished!</p>
-                <div class="game-embed">
-                    <div class="game-launcher"
-                         data-game-src="webgl/w0.3/index.html"
-                         data-game-title="Unity WebGL build: w0.3"
-                         data-game-width="960"
-                         data-game-height="600">
-                        <button type="button" class="game-play-button">
-                            <span class="game-play-icon" aria-hidden="true">&#9658;</span>
-                            Play the demo
-                        </button>
-                        <p class="game-launcher-hint"><a href="webgl/w0.3/index.html" target="_blank" rel="noopener">Open in a new tab instead</a></p>
+
+                <article class="game-section">
+                    <div class="game-section-header">
+                        <h3 class="game-section-title">Bad Game Demo (w0.3)</h3>
+                        <p class="game-section-description">The latest Unity WebGL build of the questionable platformer. Launch it below or pop it out into its own tab if you prefer.</p>
                     </div>
-                    <noscript>
-                        <p class="game-noscript">JavaScript is required to load the WebGL build on this page. <a href="webgl/w0.3/index.html" target="_blank" rel="noopener">Open the demo in a new tab.</a></p>
-                    </noscript>
-                </div>
+                    <div class="game-embed">
+                        <div class="game-launcher"
+                             data-game-src="webgl/w0.3/index.html"
+                             data-game-title="Unity WebGL build: w0.3"
+                             data-game-width="960"
+                             data-game-height="600">
+                            <p class="game-launcher-text">Press play to load the embedded demo right on this page.</p>
+                            <button type="button" class="game-play-button">
+                                <span class="game-play-icon" aria-hidden="true">&#9658;</span>
+                                Play the demo
+                            </button>
+                            <p class="game-launcher-hint"><a href="webgl/w0.3/index.html" target="_blank" rel="noopener">Open in a new tab instead</a></p>
+                        </div>
+                        <noscript>
+                            <p class="game-noscript">JavaScript is required to load the WebGL build on this page. <a href="webgl/w0.3/index.html" target="_blank" rel="noopener">Open the demo in a new tab.</a></p>
+                        </noscript>
+                    </div>
+                </article>
+
+                <article class="game-section">
+                    <div class="game-section-header">
+                        <h3 class="game-section-title">Future Project Placeholder</h3>
+                        <p class="game-section-description">Another ill-advised idea is brewing, but it needs more time in the lab before you can play it. Check back here for updates.</p>
+                    </div>
+                    <div class="game-embed">
+                        <div class="game-launcher game-launcher--disabled">
+                            <p class="game-launcher-text">A new build will appear here once there is anything remotely playable.</p>
+                            <button type="button" class="game-play-button" disabled aria-disabled="true">
+                                <span class="game-play-icon" aria-hidden="true">&#8987;</span>
+                                Coming soon
+                            </button>
+                            <p class="game-launcher-hint">Stay tuned for the next experiment.</p>
+                        </div>
+                    </div>
+                </article>
             </div>
         </section>
     </main>
@@ -58,26 +83,26 @@
         gamesYear.textContent = new Date().getFullYear();
     }
 
-    const gameLauncher = document.querySelector('.game-launcher');
-    if (gameLauncher) {
-        const playButton = gameLauncher.querySelector('.game-play-button');
-        const gameSrc = gameLauncher.dataset.gameSrc;
+    const gameLaunchers = document.querySelectorAll('.game-launcher');
+    gameLaunchers.forEach((launcher) => {
+        const playButton = launcher.querySelector('.game-play-button');
+        const gameSrc = launcher.dataset.gameSrc;
 
         if (playButton && gameSrc) {
             playButton.addEventListener('click', () => {
                 const iframe = document.createElement('iframe');
                 iframe.src = gameSrc;
-                iframe.title = gameLauncher.dataset.gameTitle || 'Unity WebGL build';
-                iframe.width = gameLauncher.dataset.gameWidth || '960';
-                iframe.height = gameLauncher.dataset.gameHeight || '600';
+                iframe.title = launcher.dataset.gameTitle || 'Unity WebGL build';
+                iframe.width = launcher.dataset.gameWidth || '960';
+                iframe.height = launcher.dataset.gameHeight || '600';
                 iframe.loading = 'lazy';
                 iframe.setAttribute('frameborder', '0');
                 iframe.setAttribute('allowfullscreen', '');
 
-                gameLauncher.replaceWith(iframe);
+                launcher.replaceWith(iframe);
             }, { once: true });
         }
-    }
+    });
     </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -138,6 +138,30 @@ body {
 }
 
 /* Embedded game wrapper on the games page */
+.game-section {
+    margin-top: 60px;
+}
+
+.game-section:first-of-type {
+    margin-top: 40px;
+}
+
+.game-section-header {
+    text-align: center;
+    max-width: 720px;
+    margin: 0 auto 30px;
+}
+
+.game-section-title {
+    margin: 0 0 12px;
+    font-size: 1.75rem;
+}
+
+.game-section-description {
+    margin: 0;
+    color: #4b5563;
+}
+
 .game-embed {
     margin-top: 40px;
     display: flex;
@@ -167,6 +191,11 @@ body {
     gap: 24px;
 }
 
+.game-launcher--disabled {
+    background: linear-gradient(135deg, #64748b 0%, #1e293b 100%);
+    color: rgba(248, 250, 252, 0.85);
+}
+
 .game-launcher-text {
     margin: 0;
     max-width: 520px;
@@ -193,6 +222,33 @@ body {
     background-color: #f4f8ff;
     transform: translateY(-2px);
     box-shadow: 0 16px 36px rgba(15, 23, 42, 0.2);
+}
+
+.game-play-button:disabled {
+    background-color: #e2e8f0;
+    color: #475569;
+    cursor: not-allowed;
+    box-shadow: none;
+    transform: none;
+}
+
+.game-play-button:disabled:hover {
+    background-color: #e2e8f0;
+    box-shadow: none;
+    transform: none;
+}
+
+.game-launcher--disabled .game-play-button {
+    background-color: rgba(248, 250, 252, 0.3);
+    color: rgba(248, 250, 252, 0.9);
+}
+
+.game-launcher--disabled .game-play-button:disabled:hover {
+    background-color: rgba(248, 250, 252, 0.3);
+}
+
+.game-launcher--disabled .game-launcher-hint {
+    color: rgba(248, 250, 252, 0.75);
 }
 
 .game-play-button:focus-visible {


### PR DESCRIPTION
## Summary
- add per-demo headings with placeholder copy above each game launcher
- introduce a disabled placeholder launcher below the existing demo for upcoming content
- update styling and script logic to support multiple launchers and disabled states

## Testing
- Not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68c97f407cf8832a8d589e79064a52e0