### PR TITLE
Allow iframe gamepad access for embedded games

### DIFF
--- a/games.html
+++ b/games.html
@@ -103,6 +103,7 @@
                 iframe.loading = 'lazy';
                 iframe.setAttribute('frameborder', '0');
                 iframe.setAttribute('allowfullscreen', '');
+                iframe.setAttribute('allow', 'autoplay; fullscreen; gamepad');
 
                 launcher.replaceWith(iframe);
             }, { once: true });


### PR DESCRIPTION
## Summary
- allow the dynamically created iframe to request access to the gamepad API
- preserve existing iframe configuration while explicitly granting fullscreen and autoplay permissions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fcf7c3d7cc832abab58eb90b16a949